### PR TITLE
Fix missing sentencepiece dependency

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -135,7 +135,7 @@ The interface is split into tabs:
    - A “Run Inference” button that checks memory, loads a small T5 model, and returns the generated text.
 
 ### 5.3 Recommended Usage in Kaggle/Google Colab 💻
-- **Install Dependencies**: `pip install gradio tensorflow psutil huggingface_hub transformers`.  
+- **Install Dependencies**: `pip install gradio tensorflow psutil sentencepiece huggingface_hub transformers`.
 - **Run Script**: The script starts the Gradio server, providing a link.  
 - **Try the Demo**: Adjust the dummy tensor size, see the wrapping effect, and optionally test text generation if memory allows.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SHAPESHIFTER is designed for **AI researchers, ML engineers, and advanced deep l
 1. Install dependencies:
 
 ```bash
-pip install gradio tensorflow psutil transformers
+pip install gradio tensorflow psutil sentencepiece transformers
 ```
 
 2. Launch the demo:

--- a/shapeshifter.py
+++ b/shapeshifter.py
@@ -89,8 +89,14 @@ def check_memory_and_infer(prompt):
     # If we have enough memory, load a small T5 model from HF (TensorFlow version)
     # We do it once for demonstration, but ideally you'd cache or load in initialization.
     model_name = "google/t5-small-ssm-nq"  # small T5 variant with TF weights
-    tokenizer = transformers.T5Tokenizer.from_pretrained(model_name)
-    t5_model = transformers.TFT5ForConditionalGeneration.from_pretrained(model_name)
+    try:
+        tokenizer = transformers.T5Tokenizer.from_pretrained(model_name)
+        t5_model = transformers.TFT5ForConditionalGeneration.from_pretrained(model_name)
+    except ImportError as exc:
+        return (
+            "Required library missing: sentencepiece. "
+            "Install it with `pip install sentencepiece` and try again."
+        )
 
     # Prepare prompt for T5: we typically prefix with "translate English to French:" or
     # "summarize: " or whatever task. For a naive text generation, we can do a simple approach:


### PR DESCRIPTION
## Summary
- update installation instructions to include `sentencepiece`
- document dependency update in DOCS
- handle missing `sentencepiece` library gracefully when loading the T5 model

## Testing
- `python - <<'PY'
from shapeshifter import check_memory_and_infer
print(check_memory_and_infer('Hello world')[:100])
PY`

------
https://chatgpt.com/codex/tasks/task_e_685a4ec4a7d883248be941a8b1ee6bdd