### PR TITLE
Fix indexing in wrap layer

### DIFF
--- a/shapeshifter.py
+++ b/shapeshifter.py
@@ -28,7 +28,7 @@ class TransversalWrapLayer(Layer):
 
     def call(self, inputs):
         """
-        Transverses the tensor to create seamless edges by wrapping rows and columns.
+        Traverses the tensor to create seamless edges by wrapping rows and columns.
 
         Expected shape: (batch_size, height, width, channels).
         Returns: (batch_size, height + 2, width + 2, channels).
@@ -38,7 +38,9 @@ class TransversalWrapLayer(Layer):
         wrapped = tf.concat([inputs[:, :, -1:], inputs, inputs[:, :, :1]], axis=2)
         # Wrap vertically by concatenating the last row on top and the first row
         # at the bottom
-        wrapped = tf.concat([wrapped[:, -1:, :], wrapped, wrapped[:, :1, :]], axis=1)
+        wrapped = tf.concat(
+            [wrapped[:, -1:, :, :], wrapped, wrapped[:, :1, :, :]], axis=1
+        )
         return wrapped
 
 ##############################################


### PR DESCRIPTION
## Summary
- correct indexing in `TransversalWrapLayer` for vertical concat
- fix small typo in docstring

## Testing
- `python -m py_compile shapeshifter.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4ec4a7d883248be941a8b1ee6bdd